### PR TITLE
[feat] 응답 핸들러 작성 

### DIFF
--- a/src/main/java/com/example/tak/config/BaseEntity.java
+++ b/src/main/java/com/example/tak/config/BaseEntity.java
@@ -1,0 +1,19 @@
+package com.example.tak.config;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/tak/config/response/ApiResponse.java
+++ b/src/main/java/com/example/tak/config/response/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.example.tak.config.response;
+
+import com.example.tak.config.response.code.BaseCode;
+import com.example.tak.config.response.code.resultCode.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonPropertyOrder("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result) {
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
+        return new ApiResponse<>(false, code, message, data);
+    }
+
+}

--- a/src/main/java/com/example/tak/config/response/code/BaseCode.java
+++ b/src/main/java/com/example/tak/config/response/code/BaseCode.java
@@ -1,0 +1,7 @@
+package com.example.tak.config.response.code;
+
+public interface BaseCode {
+    public ReasonDto getReason();
+
+    public ReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/example/tak/config/response/code/BaseErrorCode.java
+++ b/src/main/java/com/example/tak/config/response/code/BaseErrorCode.java
@@ -1,0 +1,6 @@
+package com.example.tak.config.response.code;
+
+public interface BaseErrorCode {
+    public ErrorReasonDto getReason();
+    public ErrorReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/example/tak/config/response/code/ErrorReasonDto.java
+++ b/src/main/java/com/example/tak/config/response/code/ErrorReasonDto.java
@@ -1,0 +1,19 @@
+package com.example.tak.config.response.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDto {
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess() { return isSuccess; }
+
+
+}

--- a/src/main/java/com/example/tak/config/response/code/ReasonDto.java
+++ b/src/main/java/com/example/tak/config/response/code/ReasonDto.java
@@ -1,0 +1,18 @@
+package com.example.tak.config.response.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDto {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess() { return isSuccess; }
+}

--- a/src/main/java/com/example/tak/config/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/com/example/tak/config/response/code/resultCode/ErrorStatus.java
@@ -1,0 +1,44 @@
+package com.example.tak.config.response.code.resultCode;
+
+import com.example.tak.config.response.code.BaseErrorCode;
+import com.example.tak.config.response.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 일반 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"COMMON500", "서버 에러"),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // ETF 관련 에러 응답
+    ETF_NOT_FOUND(HttpStatus.NOT_FOUND, "ETF4001", "존재하지 않는 ETF입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/tak/config/response/code/resultCode/SuccessStatus.java
+++ b/src/main/java/com/example/tak/config/response/code/resultCode/SuccessStatus.java
@@ -1,0 +1,40 @@
+package com.example.tak.config.response.code.resultCode;
+
+import com.example.tak.config.response.code.BaseCode;
+import com.example.tak.config.response.code.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+
+    // ETF 관련 성공 응답
+    ETF_SEARCH_SUCCESS(HttpStatus.OK, "ETF2001", "ETF 검색 성공");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/example/tak/config/response/exception/ExceptionAdvice.java
+++ b/src/main/java/com/example/tak/config/response/exception/ExceptionAdvice.java
@@ -1,0 +1,96 @@
+package com.example.tak.config.response.exception;
+
+import com.example.tak.config.response.ApiResponse;
+import com.example.tak.config.response.code.ErrorReasonDto;
+import com.example.tak.config.response.code.resultCode.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDto reason
+            , HttpHeaders headers, HttpServletRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/com/example/tak/config/response/exception/GeneralException.java
+++ b/src/main/java/com/example/tak/config/response/exception/GeneralException.java
@@ -1,0 +1,21 @@
+package com.example.tak.config.response.exception;
+
+import com.example.tak.config.response.code.BaseErrorCode;
+import com.example.tak.config.response.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDto getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDto getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/example/tak/config/response/exception/handler/EtfHandler.java
+++ b/src/main/java/com/example/tak/config/response/exception/handler/EtfHandler.java
@@ -1,0 +1,9 @@
+package com.example.tak.config.response.exception.handler;
+
+import com.example.tak.config.response.code.BaseErrorCode;
+
+public class EtfHandler extends GeneralHandler {
+    public EtfHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/tak/config/response/exception/handler/GeneralHandler.java
+++ b/src/main/java/com/example/tak/config/response/exception/handler/GeneralHandler.java
@@ -1,0 +1,10 @@
+package com.example.tak.config.response.exception.handler;
+
+import com.example.tak.config.response.code.BaseErrorCode;
+import com.example.tak.config.response.exception.GeneralException;
+
+public class GeneralHandler extends GeneralException {
+    public GeneralHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/tak/domain/Distribution.java
+++ b/src/main/java/com/example/tak/domain/Distribution.java
@@ -1,5 +1,6 @@
 package com.example.tak.domain;
 
+import com.example.tak.config.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Distribution {
+public class Distribution extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/tak/domain/ETF.java
+++ b/src/main/java/com/example/tak/domain/ETF.java
@@ -2,6 +2,7 @@ package com.example.tak.domain;
 
 import com.example.tak.common.Category;
 import com.example.tak.common.Nation;
+import com.example.tak.config.BaseEntity;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import jakarta.persistence.*;
 import lombok.*;
@@ -15,7 +16,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ETF {
+public class ETF extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/tak/domain/Stock.java
+++ b/src/main/java/com/example/tak/domain/Stock.java
@@ -1,5 +1,6 @@
 package com.example.tak.domain;
 
+import com.example.tak.config.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,7 +9,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Stock {
+public class Stock extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
# 구현 내용
#15 

- 엔티티의 생성 날짜를 전역적으로 적용하기 위해 BaseEntity 클래스를 구현했습니다. (@EntityListeners(AuditingEntityListener.class) 사용)
- Rest 컨트롤러에 대한 예외를 전역적으로 적용하기 위해 @RestControllerAdvice를 사용해 이를 작성했습니다. (성공 / 실패)
- 각 응답에 결과 코드를 구현했습니다. (성공 / 실패)

- 응답의 형태는 다음과 같습니다. 
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": [ 
    // 응답 데이터 
  ]
}
```